### PR TITLE
Support multiple repositories

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -2,43 +2,38 @@
 # Base branch is the targetted branch
 # Head branch is the branch with changes
 
-# Repo/branch to monitor
-repo_owner = 'appfolio'
-repo = 'landa'
-
-# PRs from these users are ignored
-ignore_login = ['example_user']
-
-# PRs targetting these branches are ignored
-ignore_base_branch = ['master']
-
-team_labels = {
-  '#Awesome': [
-    'balloob'
-    'balloobbot',
-  ],
-  'TeamMOM': [
-    'farcy',
-  ]
-}
-
-file_pattern_labels = {
-  'db_review': 'db/*',
-  'css_review': 'app/assets/stylesheets/global/*',
-  'js_review': 'node_modules/*',
-}
-
-base_branch_labels = {
-  'release/*': 'trolololol',
-}
-
-head_branch_labels = {
-  'release': 'release/*',
-}
-
-commit_status = {
-  'Farcy': 'To be done',
-  'CI - Jest': 'To be done',
-  'CI - Unit/Functional/Integration': 'To be done',
-  'CI - Selenium': 'To be done',
+repos = {
+  # owner/repo to monitor
+  'robertmaloney/LandaTest': {
+    # PRs from these users are ignored
+    'ignore_login': ['example_user'],
+    # PRs targetting these branches are ignored
+    'ignore_base_branch': ['master'],
+    'team_labels': {
+      '#Awesome': [
+        'balloob'
+        'balloobbot',
+      ],
+      'TeamMOM': [
+        'farcy',
+      ]
+    },
+    'file_pattern_labels': {
+      'db_review': 'db/*',
+      'css_review': 'app/assets/stylesheets/global/*',
+      'js_review': 'node_modules/*',
+    },
+    'base_branch_labels': {
+      'release/*': 'trolololol',
+    },
+    'head_branch_labels': {
+      'release': 'release/*',
+    },
+    'commit_status': {
+      'Farcy': 'To be done',
+      'CI - Jest': 'To be done',
+      'CI - Unit/Functional/Integration': 'To be done',
+      'CI - Selenium': 'To be done',
+    }
+  }
 }

--- a/config.example.py
+++ b/config.example.py
@@ -2,6 +2,15 @@
 # Base branch is the targetted branch
 # Head branch is the branch with changes
 
+# default configuration for all repos
+default = {
+  'team_labels': {
+    '#Lame': [
+      'balloob'
+    ]
+  }
+}
+
 repos = {
   # owner/repo to monitor
   'robertmaloney/LandaTest': {

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -7,7 +7,15 @@ import auth
 import config
 
 VERBOSE = False
-
+BASE_REPO_CONFIG = {
+    'ignore_login': [],
+    'ignore_base_branch': [],
+    'team_labels': {},
+    'file_pattern_labels': {},
+    'base_branch_labels': {},
+    'head_branch_labels': {},
+    'commit_status': {}
+}
 
 def lambda_handler(event, context, debug=False):
     if debug:
@@ -47,20 +55,24 @@ def lambda_handler(event, context, debug=False):
 
     base_repo_owner = message['pull_request']['base']['repo']['owner']['login']
     base_repo = message['pull_request']['base']['repo']['name']
+    base_repo_full_name = message['pull_request']['base']['repo']['full_name']
+
     base_branch = message['pull_request']['base']['ref']
     head_branch = message['pull_request']['head']['ref']
 
-    if base_repo_owner != config.repo_owner or base_repo != config.repo:
-        print("Got event for unexpected repo {}/{}".format(
-            base_repo_owner, base_repo))
+    if base_repo_full_name not in config.repos:
+        print("Got event for unexpected repo {}".format(base_repo_full_name))
         return
 
-    if base_branch in config.ignore_base_branch:
+    repo_config = BASE_REPO_CONFIG.copy()
+    repo_config.update(config.repos[base_repo_full_name])
+
+    if base_branch in repo_config['ignore_base_branch']:
         print('PR {} is targetting {} branch, aborting'.format(pr_id,
                                                                base_branch))
         return
 
-    if author in config.ignore_login:
+    if author in repo_config['ignore_login']:
         print('Ignoring pull request {} from {}'.format(pr_id, author))
         return
 
@@ -74,20 +86,20 @@ def lambda_handler(event, context, debug=False):
     # Calculate which labels to add and remove
     # Team Labels
     label_tests = {label: (author in users) for label, users
-                   in config.team_labels.items()}
+                   in repo_config['team_labels'].items()}
     # File Pattern Labels
     label_tests.update(
         {label: any(fnmatch(pfile.filename, pattern) for pfile
                     in files_changed) or label_tests.get(label, False)
-         for label, pattern in config.file_pattern_labels.items()})
+         for label, pattern in repo_config['file_pattern_labels'].items()})
     # Base Branch Labels
     label_tests.update(
         {label: fnmatch(base_branch, pattern) or label_tests.get(label, False)
-         for label, pattern in config.base_branch_labels.items()})
+         for label, pattern in repo_config['base_branch_labels'].items()})
     # Head Branch Labels
     label_tests.update(
         {label: fnmatch(head_branch, pattern) or label_tests.get(label, False)
-         for label, pattern in config.head_branch_labels.items()})
+         for label, pattern in repo_config['head_branch_labels'].items()})
 
     # Find labels to remove:
     remove_labels = current_labels & set(label for label, to_add
@@ -107,13 +119,13 @@ def lambda_handler(event, context, debug=False):
         if not debug:
             issue.replace_labels(list(new_labels))
 
-    if config.commit_status:
+    if repo_config['commit_status']:
         repo = gh.repository(base_repo_owner, base_repo)
         last_commit = list(pr.commits())[-1]
         current_statuses = set(status.context for status
                                in last_commit.statuses())
 
-        for context, description in config.commit_status.items():
+        for context, description in repo_config['commit_status'].items():
             if context in current_statuses:
                 print('Skipping setting commit status {}, already set.'.format(
                     context))

--- a/script/setup
+++ b/script/setup
@@ -5,4 +5,4 @@ mkdir dependencies
 # python -m pip install github3.py==1.0.0a2 -t dependencies
 # Fix some OpenSSL El Capitain stuff
 # Make sure you have: brew install openssl
-env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" python -m pip install github3.py==1.0.0a2 -t dependencies
+env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" python -m pip install github3.py==1.0.0a2 chainmap==1.0.2 -t dependencies

--- a/test_lambda.py
+++ b/test_lambda.py
@@ -1,9 +1,9 @@
 import lambda_function
 
-import config
-
-pr_id = 2324
+pr_id = 1807
 pr_author = 'balloob'
+repo_owner = 'home-assistant'
+repo = 'home-assistant'
 base_branch = 'release/78'
 head_branch = 'feature/fix-X'
 
@@ -425,8 +425,8 @@ github_event = """
 for search, replace in {
   'pr_id': str(pr_id),
   'pr_author': pr_author,
-  'repo_owner': config.repo_owner,
-  'repo': config.repo,
+  'repo_owner': repo_owner,
+  'repo': repo,
   'base_branch': base_branch,
   'head_branch': head_branch,
 }.items():


### PR DESCRIPTION
Config is now kept in a single `repo` dictionary. Additionally, the test case has been changed to point to home-assistant/home-assistant#1807 by default, since `login` is not currently mocked.
