### PR TITLE
Allow file pattern labels to be regex

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -2,6 +2,8 @@
 # Base branch is the targetted branch
 # Head branch is the branch with changes
 
+import re
+
 # default configuration for all repos
 default = {
   'team_labels': {
@@ -31,7 +33,9 @@ repos = {
       'db_review': 'db/*',
       'css_review': 'app/assets/stylesheets/global/*',
       'js_review': 'node_modules/*',
-      'ops_review': ['config/nginx/*', 'config/settings/*']
+      'ops_review': ['config/nginx/*', 'config/settings/*'],
+      # Only matches files in this folder, not any subfolder
+      'test_review': re.compile(r'test\/[a-z_]+.rb'),
     },
     'base_branch_labels': {
       'release/*': 'trolololol',

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -110,8 +110,14 @@ def lambda_handler(event, context, debug=False):
             patterns = [patterns]
 
         for pattern in patterns:
-            if any(fnmatch(pfile.filename, pattern) for pfile
-                   in files_changed):
+            if isinstance(pattern, str):
+                match = any(fnmatch(pfile.filename, pattern) for pfile
+                            in files_changed)
+            else:
+                match = any(pattern.match(pfile.filename) is not None for pfile
+                            in files_changed)
+
+            if match:
                 label_tests[label] = True
                 break
 


### PR DESCRIPTION
Landa was using `fnmatch` to match file paths vs patterns to see if a label had to be applied or not.

Sadly, this makes it impossible to match just the files in a directory versus the files in any of the subdirectories of a directory.