### PR TITLE
ps - use environment for auth variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ Landa runs on AWS Lambda using Python 2.7. It uses GitHub webhooks as triggers.
 ## Getting started
 
  - Create a Python 2.7 lambda function in AWS and enable the API gateway for this function.
+ - For the Python 2.7 lambda function, set up the following environment variables GH_USER and GH_TOKEN ([create token here](https://github.com/settings/tokens)).
  - On GitHub, go to your repo settings -> Webhooks & Services -> Add webhook:
     - Payload URL: the URL of your lambda function
     - Content type: application/json
     - Secret: <empty>
     - Which events: click "Let me select individual events" and make sure only "Pull Requests" is selected.
     - Active: checked
- - Clone the repo and copy `auth.example.py` to `auth.py` and `config.example.py` to `config.py` and adjust appropriately.
+ - Clone the repo and copy `config.example.py` to `config.py` and adjust appropriately.
  - Run `script/setup` to install the dependencies.
  - Adjust `script/deploy` to match your Lambda function name
  - Install AWS-cli: `pip install awscli`

--- a/auth.example.py
+++ b/auth.example.py
@@ -1,4 +1,0 @@
-# Copy this file to auth.py
-user = 'balloobbot'
-# Get at https://github.com/settings/tokens
-token = 'SOME_SECRET_TOKEN'

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -3,8 +3,8 @@ from __future__ import print_function
 from fnmatch import fnmatch
 from chainmap import ChainMap
 import json
+import os
 
-import auth
 import config
 
 config.repos = {key.lower(): value for key, value in config.repos.items()}
@@ -19,11 +19,17 @@ EMPTY_REPO_CONFIG = {
     'head_branch_labels': {},
     'commit_status': {}
 }
+ENV_KEYS = ['GH_USER', 'GH_TOKEN']
 
 
 def lambda_handler(event, context, debug=False):
+    missing = [key for key in ENV_KEYS if key not in os.environ]
+
+    if missing:
+        print('Missing required environment keys:', ', '.join(missing))
+        return
+
     if debug:
-        import os
         import sys
         sys.path.insert(0, os.path.join(os.path.dirname(__file__),
                         'dependencies'))
@@ -87,7 +93,7 @@ def lambda_handler(event, context, debug=False):
         print('Ignoring pull request {} from {}'.format(pr_id, author))
         return
 
-    gh = login(auth.user, password=auth.token)
+    gh = login(os.environ['GH_USER'], password=os.environ['GH_TOKEN'])
 
     issue = gh.issue(base_repo_owner, base_repo, pr_id)
     pr = gh.pull_request(base_repo_owner, base_repo, pr_id)

--- a/script/deploy
+++ b/script/deploy
@@ -1,7 +1,7 @@
 cd "$(dirname "$0")/.."
 
 rm -rf build/*
-zip -r build/upload.zip auth.py config.py lambda_function.py
+zip -r build/upload.zip config.py lambda_function.py
 cd dependencies
 zip -r ../build/upload.zip *
 cd ..


### PR DESCRIPTION
Use environment variables `GH_USER` and `GH_TOKEN` instead of an auth file.