### PR TITLE
ps - remove replace label, just do add/remove

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -162,7 +162,6 @@ def lambda_handler(event, context, debug=False):
                 issue.add_labels(*add_labels)
             for label in remove_labels:
                 issue.remove_label(label)
-            issue.replace_labels(list(new_labels))
 
     if repo_config['commit_status']:
         repo = gh.repository(base_repo_owner, base_repo)


### PR DESCRIPTION
I forgot to remove the invocation of replace label when I added add and remove.